### PR TITLE
Bugfix/kdl forward kinematics with multiple frames

### DIFF
--- a/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
+++ b/moveit_kinematics/kdl_kinematics_plugin/include/moveit/kdl_kinematics_plugin/kdl_kinematics_plugin.h
@@ -156,6 +156,9 @@ private:
   /// clip q_delta such that joint limits will not be violated
   void clipToJointLimits(const KDL::JntArray& q, KDL::JntArray& q_delta, Eigen::ArrayXd& weighting) const;
 
+  // Given a set of link names, returns their indices in the joint model group
+  std::vector<unsigned int> getLinkIndices(const std::vector<std::string> & link_names) const;
+
   bool initialized_;  ///< Internal variable that indicates whether solver is configured and ready
 
   unsigned int dimension_;                        ///< Dimension of the group

--- a/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
+++ b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp
@@ -535,14 +535,19 @@ bool KDLKinematicsPlugin::getPositionFK(const std::vector<std::string>& link_nam
     return false;
   }
 
-  KDL::Frame p_out;
   KDL::JntArray jnt_pos_in(dimension_);
   jnt_pos_in.data = Eigen::Map<const Eigen::VectorXd>(joint_angles.data(), joint_angles.size());
 
   bool valid = true;
   for (unsigned int i = 0; i < poses.size(); i++)
   {
-    if (fk_solver_->JntToCart(jnt_pos_in, p_out) >= 0)
+    KDL::Frame p_out;
+
+    int link_index = joint_model_group_->getLinkModel(link_names[i])->getLinkIndex();
+
+    ROS_INFO("Link index = %d", link_index);
+
+    if (fk_solver_->JntToCart(jnt_pos_in, p_out, link_index) >= 0)
     {
       poses[i] = tf2::toMsg(p_out);
     }

--- a/moveit_kinematics/test/test_kinematics_plugin.cpp
+++ b/moveit_kinematics/test/test_kinematics_plugin.cpp
@@ -326,6 +326,25 @@ TEST_F(KinematicsTest, getFK)
   }
 }
 
+// Test that different poses are returned when querying FK with multiple intermediate frames
+TEST_F(KinematicsTest, getMultipleIntermediateFK)
+{
+  std::vector<double> joints(kinematics_solver_->getJointNames().size(), 0.0);
+  const std::vector<std::string>& link_names = jmg_->getLinkModelNames();
+  std::vector<geometry_msgs::Pose> fk_poses;
+  EXPECT_TRUE(kinematics_solver_->getPositionFK(link_names, joints, fk_poses));
+
+  moveit::core::RobotState robot_state(robot_model_);
+  robot_state.setJointGroupPositions(jmg_, joints);
+  robot_state.updateLinkTransforms();
+  std::vector<geometry_msgs::Pose> model_poses;
+  model_poses.reserve(link_names.size());
+  int i = 0;
+  for (const auto& frame : link_names)
+    model_poses.emplace_back(tf2::toMsg(robot_state.getGlobalLinkTransform(frame)));
+  EXPECT_NEAR_POSES(model_poses, fk_poses, tolerance_);
+}
+
 // perform random walk in joint-space, reaching poses via IK
 TEST_F(KinematicsTest, randomWalkIK)
 {


### PR DESCRIPTION
### Description

This PR allows computing FK with KDL for intermediate frames (frames that are not the tip of the chain). It closes issue #2572.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
