### PR TITLE
evenly sampled pilz joint trajectory

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_functions.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_functions.h
@@ -132,7 +132,7 @@ bool generateJointTrajectory(const planning_scene::PlanningSceneConstPtr& scene,
                              const JointLimitsContainer& joint_limits, const KDL::Trajectory& trajectory,
                              const std::string& group_name, const std::string& link_name,
                              const Eigen::Translation3d& offset,
-                             const std::map<std::string, double>& initial_joint_position, const double& sampling_time,
+                             const std::map<std::string, double>& initial_joint_position, double sampling_time,
                              trajectory_msgs::JointTrajectory& joint_trajectory,
                              moveit_msgs::MoveItErrorCodes& error_code, bool check_self_collision = false);
 

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator.h
@@ -158,7 +158,7 @@ private:
 
   virtual void plan(const planning_scene::PlanningSceneConstPtr& scene,
                     const planning_interface::MotionPlanRequest& req, const MotionPlanInfo& plan_info,
-                    const double& sampling_time, trajectory_msgs::JointTrajectory& joint_trajectory) = 0;
+                    double sampling_time, trajectory_msgs::JointTrajectory& joint_trajectory) = 0;
 
 private:
   /**

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_circ.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_circ.h
@@ -88,7 +88,7 @@ private:
                              const planning_interface::MotionPlanRequest& req, MotionPlanInfo& info) const final;
 
   void plan(const planning_scene::PlanningSceneConstPtr& scene, const planning_interface::MotionPlanRequest& req,
-            const MotionPlanInfo& plan_info, const double& sampling_time,
+            const MotionPlanInfo& plan_info, double sampling_time,
             trajectory_msgs::JointTrajectory& joint_trajectory) override;
 
   /**

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_lin.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_lin.h
@@ -75,7 +75,7 @@ private:
                              const planning_interface::MotionPlanRequest& req, MotionPlanInfo& info) const final;
 
   void plan(const planning_scene::PlanningSceneConstPtr& scene, const planning_interface::MotionPlanRequest& req,
-            const MotionPlanInfo& plan_info, const double& sampling_time,
+            const MotionPlanInfo& plan_info, double sampling_time,
             trajectory_msgs::JointTrajectory& joint_trajectory) override;
 
   /**

--- a/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_ptp.h
+++ b/moveit_planners/pilz_industrial_motion_planner/include/pilz_industrial_motion_planner/trajectory_generator_ptp.h
@@ -82,10 +82,10 @@ private:
    */
   void planPTP(const std::map<std::string, double>& start_pos, const std::map<std::string, double>& goal_pos,
                trajectory_msgs::JointTrajectory& joint_trajectory, const double& velocity_scaling_factor,
-               const double& acceleration_scaling_factor, const double& sampling_time);
+               const double& acceleration_scaling_factor, double sampling_time);
 
   void plan(const planning_scene::PlanningSceneConstPtr& scene, const planning_interface::MotionPlanRequest& req,
-            const MotionPlanInfo& plan_info, const double& sampling_time,
+            const MotionPlanInfo& plan_info, double sampling_time,
             trajectory_msgs::JointTrajectory& joint_trajectory) override;
 
 private:

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
@@ -188,7 +188,7 @@ bool pilz_industrial_motion_planner::generateJointTrajectory(
     const planning_scene::PlanningSceneConstPtr& scene,
     const pilz_industrial_motion_planner::JointLimitsContainer& joint_limits, const KDL::Trajectory& trajectory,
     const std::string& group_name, const std::string& link_name, const Eigen::Translation3d& offset,
-    const std::map<std::string, double>& initial_joint_position, const double& sampling_time,
+    const std::map<std::string, double>& initial_joint_position, double sampling_time,
     trajectory_msgs::JointTrajectory& joint_trajectory, moveit_msgs::MoveItErrorCodes& error_code,
     bool check_self_collision)
 {

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
@@ -198,10 +198,10 @@ bool pilz_industrial_motion_planner::generateJointTrajectory(
   ros::Time generation_begin = ros::Time::now();
 
   // generate the time samples
-  std::vector<double> time_samples = { 0.0 };
+  std::vector<double> time_samples;
   const unsigned num_segments = std::ceil(trajectory.Duration() / sampling_time);
   sampling_time = trajectory.Duration() / num_segments;
-  for (unsigned i = 1; i <= num_segments; ++i)
+  for (unsigned i = 0; i <= num_segments; ++i)
   {
     time_samples.push_back(i * sampling_time);
   }

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
@@ -264,8 +264,7 @@ bool pilz_industrial_motion_planner::generateJointTrajectory(
 
       if (time_iter != time_samples.begin() && time_iter != time_samples.end() - 1)
       {
-        double joint_velocity =
-            (ik_solution.at(joint_name) - ik_solution_last.at(joint_name)) / duration_current_sample;
+        double joint_velocity = (ik_solution.at(joint_name) - ik_solution_last.at(joint_name)) / actual_sampling_time;
         point.velocities.push_back(joint_velocity);
         point.accelerations.push_back((joint_velocity - joint_velocity_last.at(joint_name)) / actual_sampling_time * 4);
         joint_velocity_last[joint_name] = joint_velocity;

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_functions.cpp
@@ -266,7 +266,7 @@ bool pilz_industrial_motion_planner::generateJointTrajectory(
       {
         double joint_velocity = (ik_solution.at(joint_name) - ik_solution_last.at(joint_name)) / actual_sampling_time;
         point.velocities.push_back(joint_velocity);
-        point.accelerations.push_back((joint_velocity - joint_velocity_last.at(joint_name)) / actual_sampling_time * 4);
+        point.accelerations.push_back((joint_velocity - joint_velocity_last.at(joint_name)) / actual_sampling_time);
         joint_velocity_last[joint_name] = joint_velocity;
       }
       else

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_circ.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_circ.cpp
@@ -184,7 +184,7 @@ void TrajectoryGeneratorCIRC::extractMotionPlanInfo(const planning_scene::Planni
 
 void TrajectoryGeneratorCIRC::plan(const planning_scene::PlanningSceneConstPtr& scene,
                                    const planning_interface::MotionPlanRequest& req, const MotionPlanInfo& plan_info,
-                                   const double& sampling_time, trajectory_msgs::JointTrajectory& joint_trajectory)
+                                   double sampling_time, trajectory_msgs::JointTrajectory& joint_trajectory)
 {
   std::unique_ptr<KDL::Path> cart_path(setPathCIRC(plan_info));
   std::unique_ptr<KDL::VelocityProfile> vel_profile(

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lin.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_lin.cpp
@@ -141,7 +141,7 @@ void TrajectoryGeneratorLIN::extractMotionPlanInfo(const planning_scene::Plannin
 
 void TrajectoryGeneratorLIN::plan(const planning_scene::PlanningSceneConstPtr& scene,
                                   const planning_interface::MotionPlanRequest& req, const MotionPlanInfo& plan_info,
-                                  const double& sampling_time, trajectory_msgs::JointTrajectory& joint_trajectory)
+                                  double sampling_time, trajectory_msgs::JointTrajectory& joint_trajectory)
 {
   // create Cartesian path for lin
   std::unique_ptr<KDL::Path> path(setPathLIN(plan_info.start_pose, plan_info.goal_pose));

--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_generator_ptp.cpp
@@ -82,7 +82,7 @@ void TrajectoryGeneratorPTP::planPTP(const std::map<std::string, double>& start_
                                      const std::map<std::string, double>& goal_pos,
                                      trajectory_msgs::JointTrajectory& joint_trajectory,
                                      const double& velocity_scaling_factor, const double& acceleration_scaling_factor,
-                                     const double& sampling_time)
+                                     double sampling_time)
 {
   // initialize joint names
   for (const auto& item : goal_pos)
@@ -252,7 +252,7 @@ void TrajectoryGeneratorPTP::extractMotionPlanInfo(const planning_scene::Plannin
 
 void TrajectoryGeneratorPTP::plan(const planning_scene::PlanningSceneConstPtr& /*scene*/,
                                   const planning_interface::MotionPlanRequest& req, const MotionPlanInfo& plan_info,
-                                  const double& sampling_time, trajectory_msgs::JointTrajectory& joint_trajectory)
+                                  double sampling_time, trajectory_msgs::JointTrajectory& joint_trajectory)
 {
   // plan the ptp trajectory
   planPTP(plan_info.start_joint_position, plan_info.goal_joint_position, joint_trajectory,

--- a/moveit_planners/pilz_industrial_motion_planner/test/test_utils.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/test/test_utils.cpp
@@ -1038,9 +1038,9 @@ bool testutils::getBlendTestData(const ros::NodeHandle& nh, const size_t& datase
 bool testutils::generateTrajFromBlendTestData(
     const planning_scene::PlanningSceneConstPtr& scene,
     const std::shared_ptr<pilz_industrial_motion_planner::TrajectoryGenerator>& tg, const std::string& group_name,
-    const std::string& link_name, const testutils::BlendTestData& data, const double& sampling_time_1,
-    const double& sampling_time_2, planning_interface::MotionPlanResponse& res_1,
-    planning_interface::MotionPlanResponse& res_2, double& dis_1, double& dis_2)
+    const std::string& link_name, const testutils::BlendTestData& data, double sampling_time_1, double sampling_time_2,
+    planning_interface::MotionPlanResponse& res_1, planning_interface::MotionPlanResponse& res_2, double& dis_1,
+    double& dis_2)
 {
   const robot_model::RobotModelConstPtr robot_model = scene->getRobotModel();
 

--- a/moveit_planners/pilz_industrial_motion_planner/test/test_utils.h
+++ b/moveit_planners/pilz_industrial_motion_planner/test/test_utils.h
@@ -433,8 +433,8 @@ bool checkBlendResult(const pilz_industrial_motion_planner::TrajectoryBlendReque
 bool generateTrajFromBlendTestData(const planning_scene::PlanningSceneConstPtr& scene,
                                    const std::shared_ptr<pilz_industrial_motion_planner::TrajectoryGenerator>& tg,
                                    const std::string& group_name, const std::string& link_name,
-                                   const BlendTestData& data, const double& sampling_time_1,
-                                   const double& sampling_time_2, planning_interface::MotionPlanResponse& res_lin_1,
+                                   const BlendTestData& data, double sampling_time_1, double sampling_time_2,
+                                   planning_interface::MotionPlanResponse& res_lin_1,
                                    planning_interface::MotionPlanResponse& res_lin_2, double& dis_lin_1,
                                    double& dis_lin_2);
 


### PR DESCRIPTION
### Description

Changes made in reference to #3553

Evenly spaces time samples in generateJointTrajectory.

Previously, if `trajectory.Duration()` was just above a multiple of `sampling_time` (e.g. `trajectory.Duration()=0.5004` and `sampling_time=0.1`), the final slice in the trajectory would have a tiny time (`0.0004` in the example). This massively amplifies small variations in IK, leading to joint velocity limit violations.

With this PR, the trajectory is evenly sampled, at a rate approximating `sampling_time`.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/ros-planning/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
