### PR TITLE
PipelinePlanner: Truncate trajectory to valid part

### DIFF
--- a/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
+++ b/moveit_core/robot_trajectory/include/moveit/robot_trajectory/robot_trajectory.h
@@ -227,6 +227,9 @@ public:
   RobotTrajectory& append(const RobotTrajectory& source, double dt, size_t start_index = 0,
                           size_t end_index = std::numeric_limits<std::size_t>::max());
 
+  /** Truncate trajectory to given size */
+  void truncate(size_t size);
+
   void swap(robot_trajectory::RobotTrajectory& other);
 
   RobotTrajectory& clear()

--- a/moveit_core/robot_trajectory/src/robot_trajectory.cpp
+++ b/moveit_core/robot_trajectory/src/robot_trajectory.cpp
@@ -117,6 +117,13 @@ RobotTrajectory& RobotTrajectory::append(const RobotTrajectory& source, double d
   return *this;
 }
 
+void RobotTrajectory::truncate(size_t size)
+{
+  size = std::min(size, waypoints_.size());
+  waypoints_.resize(size);
+  duration_from_previous_.resize(size);
+}
+
 RobotTrajectory& RobotTrajectory::reverse()
 {
   std::reverse(waypoints_.begin(), waypoints_.end());

--- a/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
+++ b/moveit_ros/planning/planning_pipeline/src/planning_pipeline.cpp
@@ -337,6 +337,7 @@ bool planning_pipeline::PlanningPipeline::generatePlan(const planning_scene::Pla
               }
             }
             ROS_ERROR_STREAM("Completed listing of explanations for invalid states.");
+            res.trajectory_->truncate(index[0]);  // truncate returned trajectory to valid part
           }
         }
         else


### PR DESCRIPTION
Fixes https://github.com/ros-planning/moveit_task_constructor/pull/538

Some planners, like Pilz, return a trajectory, which is partially invalid.
However, MTC's MoveRelative stage relies on the fact that the returned trajectory is valid (or empty if that's not possible).
This PR truncates the trajectory to the valid part.

Alternatively, the truncation should happen in MTC's MoveRelative stage only.
Do we need the invalid part of the trajectory to be returned (and displayed)?

Open issues: Performing late truncation, like proposed here, will invalidate the time parameterization of the trajectory computed earlier by the pipeline. Maybe, we should better have a planning adapter performing the truncation for MTC before calculating the timing. This, of course, would duplicate the validity check :disappointed: 