### PR TITLE
Optimize FCL move shape

### DIFF
--- a/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_panda.h
+++ b/moveit_core/collision_detection/include/moveit/collision_detection/test_collision_common_panda.h
@@ -155,9 +155,22 @@ TYPED_TEST_P(CollisionDetectorPandaTest, RobotWorldCollision_1)
   ASSERT_TRUE(res.collision);
   res.clear();
 
+  pos1.translation().z() = 0.25;
+  this->cenv_->getWorld()->moveObject("box", pos1);
+  this->cenv_->checkRobotCollision(req, res, *this->robot_state_, *this->acm_);
+  ASSERT_FALSE(res.collision);
+  res.clear();
+
+  pos1.translation().z() = 0.05;
   this->cenv_->getWorld()->moveObject("box", pos1);
   this->cenv_->checkRobotCollision(req, res, *this->robot_state_, *this->acm_);
   ASSERT_TRUE(res.collision);
+  res.clear();
+
+  pos1.translation().z() = 0.25;
+  this->cenv_->getWorld()->moveObject("box", pos1);
+  this->cenv_->checkRobotCollision(req, res, *this->robot_state_, *this->acm_);
+  ASSERT_FALSE(res.collision);
   res.clear();
 
   this->cenv_->getWorld()->moveObject("box", pos1);

--- a/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
@@ -453,7 +453,18 @@ void CollisionEnvFCL::notifyObjectChange(const ObjectConstPtr& obj, World::Actio
     }
 
     for (std::size_t i = 0; i < it->second.collision_objects_.size(); ++i)
+    {
       it->second.collision_objects_[i]->setTransform(transform2fcl(obj->global_shape_poses_[i]));
+
+      // compute AABB, order matters
+      it->second.collision_geometry_[i]->collision_geometry_->computeLocalAABB();
+      it->second.collision_objects_[i]->computeAABB();
+    }
+
+    // update AABB in the FCL broadphase manager tree
+    // see https://github.com/moveit/moveit/pull/3601 for benchmarks
+    it->second.unregisterFrom(manager_.get());
+    it->second.registerTo(manager_.get());
   }
   else
   {

--- a/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
@@ -437,20 +437,23 @@ void CollisionEnvFCL::notifyObjectChange(const ObjectConstPtr& obj, World::Actio
   else if (action == World::MOVE_SHAPE)
   {
     auto it = fcl_objs_.find(obj->id_);
-    if (it != fcl_objs_.end())
+    if (it == fcl_objs_.end())
     {
-      if (obj->global_shape_poses_.size() == it->second.collision_objects_.size())
-      {
-        for (std::size_t i = 0; i < it->second.collision_objects_.size(); ++i)
-          it->second.collision_objects_[i]->setTransform(transform2fcl(obj->global_shape_poses_[i]));
-        return;
-      }
+      ROS_ERROR_NAMED(LOGNAME, "Cannot move shapes of unknown FCL object: '%s'", obj->id_.c_str());
+      return;
+    }
+
+    if (obj->global_shape_poses_.size() != it->second.collision_objects_.size())
+    {
       ROS_ERROR_NAMED(LOGNAME,
                       "Cannot move shapes, shape size mismatch between FCL object and world object: '%s'. Respectively "
                       "%zu and %zu.",
                       obj->id_.c_str(), it->second.collision_objects_.size(), it->second.collision_objects_.size());
+      return;
     }
-    ROS_ERROR_NAMED(LOGNAME, "Cannot move shapes of unknown FCL object: '%s'", obj->id_.c_str());
+
+    for (std::size_t i = 0; i < it->second.collision_objects_.size(); ++i)
+      it->second.collision_objects_[i]->setTransform(transform2fcl(obj->global_shape_poses_[i]));
   }
   else
   {

--- a/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
+++ b/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp
@@ -434,6 +434,24 @@ void CollisionEnvFCL::notifyObjectChange(const ObjectConstPtr& obj, World::Actio
     }
     cleanCollisionGeometryCache();
   }
+  else if (action == World::MOVE_SHAPE)
+  {
+    auto it = fcl_objs_.find(obj->id_);
+    if (it != fcl_objs_.end())
+    {
+      if (obj->global_shape_poses_.size() == it->second.collision_objects_.size())
+      {
+        for (std::size_t i = 0; i < it->second.collision_objects_.size(); ++i)
+          it->second.collision_objects_[i]->setTransform(transform2fcl(obj->global_shape_poses_[i]));
+        return;
+      }
+      ROS_ERROR_NAMED(LOGNAME,
+                      "Cannot move shapes, shape size mismatch between FCL object and world object: '%s'. Respectively "
+                      "%zu and %zu.",
+                      obj->id_.c_str(), it->second.collision_objects_.size(), it->second.collision_objects_.size());
+    }
+    ROS_ERROR_NAMED(LOGNAME, "Cannot move shapes of unknown FCL object: '%s'", obj->id_.c_str());
+  }
   else
   {
     updateFCLObject(obj->id_);


### PR DESCRIPTION
### Description
Related to #3599.

Updating a MoveIt Collision object shape poses takes 0.3 seconds for an object with 3 meshes with a total of 48,064 triangles. 

When the FCL collision environment is notified by a World::CREATE | MOVE_SHAPE | ADD_SHAPE | REMOVE_SHAPE, the object is reconstructed from scratch as seen [here](https://github.com/moveit/moveit/blob/master/moveit_core/collision_detection_fcl/src/collision_env_fcl.cpp#L424-L443).

This PR only updates the FCL object transforms when encountering the `MOVE_SHAPE` action. The time is reduced to an average of 16 microseconds.
