### PR TITLE
PSM: Correctly handle full planning scene message

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1264,6 +1264,7 @@ void PlanningScene::decoupleParent()
 
 bool PlanningScene::setPlanningSceneDiffMsg(const moveit_msgs::PlanningScene& scene_msg)
 {
+  assert(scene_msg.is_diff == true);
   bool result = true;
 
   ROS_DEBUG_NAMED(LOGNAME, "Adding planning scene diff");
@@ -1318,6 +1319,7 @@ bool PlanningScene::setPlanningSceneDiffMsg(const moveit_msgs::PlanningScene& sc
 
 bool PlanningScene::setPlanningSceneMsg(const moveit_msgs::PlanningScene& scene_msg)
 {
+  assert(scene_msg.is_diff == false);
   ROS_DEBUG_NAMED(LOGNAME, "Setting new planning scene: '%s'", scene_msg.name.c_str());
   name_ = scene_msg.name;
 

--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -1264,7 +1264,6 @@ void PlanningScene::decoupleParent()
 
 bool PlanningScene::setPlanningSceneDiffMsg(const moveit_msgs::PlanningScene& scene_msg)
 {
-  assert(scene_msg.is_diff == true);
   bool result = true;
 
   ROS_DEBUG_NAMED(LOGNAME, "Adding planning scene diff");

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -592,7 +592,7 @@ bool PlanningSceneMonitor::newPlanningSceneMessage(const moveit_msgs::PlanningSc
     }
     else
     {
-      result = scene_->setPlanningSceneDiffMsg(scene);
+      result = scene_->usePlanningSceneMsg(scene);
     }
 
     if (octomap_monitor_)


### PR DESCRIPTION
Fixes #3538/#3609
If the message is not a diff and parent_scene is not set either, the message should be handled as a full planning scene message as before #3538.
