### PR TITLE
Restrict to single IK attempt by using minimal timeout

### DIFF
--- a/moveit_core/robot_state/src/cartesian_interpolator.cpp
+++ b/moveit_core/robot_state/src/cartesian_interpolator.cpp
@@ -157,9 +157,10 @@ double CartesianInterpolator::computeCartesianPath(RobotState* start_state, cons
     Eigen::Isometry3d pose(start_quaternion.slerp(percentage, target_quaternion));
     pose.translation() = percentage * rotated_target.translation() + (1 - percentage) * start_pose.translation();
 
-    // Explicitly use a single IK attempt only: We want a smooth trajectory.
+    // Explicitly use a single IK attempt only (minimal timeout): We want a smooth trajectory.
     // Random seeding (of additional attempts) would probably create IK jumps.
-    if (start_state->setFromIK(group, pose * offset, link->getName(), consistency_limits, 0.0, validCallback, options))
+    if (start_state->setFromIK(group, pose * offset, link->getName(), consistency_limits,
+                               std::numeric_limits<double>::epsilon(), validCallback, options))
       traj.push_back(std::make_shared<moveit::core::RobotState>(*start_state));
     else
       break;


### PR DESCRIPTION
When the (KDL) IK solver is called with a sufficiently large timeout, it will not bail out after the first failed IK attempt, but try other attempts starting from randomly sampled seeds:
https://github.com/moveit/moveit/blob/e8eb9c11053cdd8f1acf9d224dc56f7a8d691677/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp#L381

This will typically lead to a solution on a different solution branch, i.e. having a large joint-space distance to the original seed state, causing a large, unexpected motion like in this example:
![cartesianPath](https://github.com/moveit/moveit/assets/5376030/72ec5f1d-7f39-46b8-9318-6d9c9d62f546)

```
0:     0.245      2.657     -0.886     -3.339       1.19     -0.064    1.39371      1.238
1:  0.244708    2.67123  -0.884611   -3.35363    1.19068 -0.0737556    1.39372    1.23779
2:  0.337582    2.66722  0.0126484   0.215952   0.954576   0.143617   -1.39372  -0.676787
3:  0.337241    2.67777  0.0132923   0.223466   0.956462   0.156359   -1.39372  -0.677865
```
For this reason, setFromIK was called with a zero timeout in the past:
https://github.com/moveit/moveit/blob/e8eb9c11053cdd8f1acf9d224dc56f7a8d691677/moveit_core/robot_state/src/cartesian_interpolator.cpp#L162

However, it turned out that this zero timeout is reset to DefaultIKTimeout before being passed to the IK solver:
https://github.com/moveit/moveit/blob/e8eb9c11053cdd8f1acf9d224dc56f7a8d691677/moveit_core/robot_state/src/robot_state.cpp#L1961-L1963

Thus, still flips can occur. Now, we set the minimal accepted timeout to force a single solution attempt.

A clean solution will use a different approach to check for joint-space jumps...
