### PR TITLE
Fix race condition in trajectory execution

### DIFF
--- a/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
+++ b/moveit_plugins/moveit_simple_controller_manager/include/moveit_simple_controller_manager/action_based_controller_handle.h
@@ -117,12 +117,6 @@ public:
   {
     if (controller_action_client_ && !done_)
       return controller_action_client_->waitForResult(timeout);
-#if 1  // TODO: remove when https://github.com/ros/actionlib/issues/155 is fixed
-    // workaround for actionlib issue: waitForResult() might return before our doneCB finished
-    ros::Time deadline = ros::Time::now() + ros::Duration(0.1);  // limit waiting to 0.1s
-    while (!done_ && ros::ok() && ros::Time::now() < deadline)   // Check the done_ flag explicitly,
-      ros::Duration(0.0001).sleep();                             // which is eventually set in finishControllerExecution
-#endif
     return true;
   }
 

--- a/moveit_plugins/moveit_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
+++ b/moveit_plugins/moveit_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp
@@ -62,11 +62,11 @@ bool FollowJointTrajectoryControllerHandle::sendTrajectory(const moveit_msgs::Ro
 
   control_msgs::FollowJointTrajectoryGoal goal = goal_template_;
   goal.trajectory = trajectory.joint_trajectory;
+  done_ = false;
+  last_exec_ = moveit_controller_manager::ExecutionStatus::RUNNING;
   controller_action_client_->sendGoal(
       goal, [this](const auto& state, const auto& result) { controllerDoneCallback(state, result); },
       [this] { controllerActiveCallback(); }, [this](const auto& feedback) { controllerFeedbackCallback(feedback); });
-  done_ = false;
-  last_exec_ = moveit_controller_manager::ExecutionStatus::RUNNING;
   return true;
 }
 


### PR DESCRIPTION
When executing an MTC solution, colleagues observed the following warning. Subsequently, the solution execution was not continued:
```
[DEBUG] [1720618064.381530365]: new trajectory to arm_controller
[DEBUG] [1720618064.381566831]: sending trajectory to arm_controller
[DEBUG] [1720618064.381634257]: new trajectory to torso_controller
[DEBUG] [1720618064.381663195]: sending trajectory to torso_controller
[DEBUG] [1720618064.382548006]: arm_controller started execution
[DEBUG] [1720618064.382680992]: torso_controller started execution
[ INFO] [1720618065.533005312]: Controller 'torso_controller' successfully finished
[DEBUG] [1720618065.533084152]: Controller torso_controller is done with state SUCCEEDED: 
[ INFO] [1720618065.982645786]: Controller 'arm_controller' successfully finished
[ WARN] [1720618065.982870745]: Controller handle arm_controller reports status RUNNING
[ INFO] [1720618065.983129234]: Completed trajectory execution with status RUNNING ...
[DEBUG] [1720618065.983287836]: Controller arm_controller is done with state SUCCEEDED: 
```
Thus, although reporting "successfully finished" in `FollowJointTrajectoryControllerHandle::controllerDoneCallback()`:
https://github.com/moveit/moveit/blob/8158891d6f63807b1208ab441d8814ee9cf4e076/moveit_plugins/moveit_simple_controller_manager/src/follow_joint_trajectory_controller_handle.cpp#L203
 the status is reported to be RUNNING, when checking later in `TrajectoryExecutionManager::executePart()`:
https://github.com/moveit/moveit/blob/8158891d6f63807b1208ab441d8814ee9cf4e076/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp#L1297-L1298
I attribute that to the fact, that the status was reset to `RUNNING` after calling `sendGoal()`. If the thread is interrupted in between and the doneCallback is called before `RUNNING` can be set, we would get the observed behavior.
Now the status is reset before `sendGoal()`.

@LeroyR, please verify.