### PR TITLE
Fix Pilz trajectory time stamps

### DIFF
--- a/moveit_planners/pilz_industrial_motion_planner/src/trajectory_blender_transition_window.cpp
+++ b/moveit_planners/pilz_industrial_motion_planner/src/trajectory_blender_transition_window.cpp
@@ -61,7 +61,7 @@ bool pilz_industrial_motion_planner::TrajectoryBlenderTransitionWindow::blend(
   std::size_t second_intersection_index;
   if (!searchIntersectionPoints(req, first_intersection_index, second_intersection_index))
   {
-    ROS_ERROR("Blend radius to large.");
+    ROS_ERROR("Blend radius too large.");
     res.error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_MOTION_PLAN;
     return false;
   }
@@ -118,6 +118,7 @@ bool pilz_industrial_motion_planner::TrajectoryBlenderTransitionWindow::blend(
 
   // append the blend trajectory
   res.blend_trajectory->setRobotTrajectoryMsg(req.first_trajectory->getFirstWayPoint(), blend_joint_trajectory);
+
   // copy the points [second_intersection_index, len] from the second trajectory
   for (size_t i = second_intersection_index + 1; i < req.second_trajectory->getWayPointCount(); ++i)
   {


### PR DESCRIPTION
Backport of https://github.com/moveit/moveit2/pull/2961

The Pilz planner generated trajectories with identical subsequent time stamps, which were rejected by the ROS controllers.

Pilz's `appendWithStrictTimeIncrease()` function had a single if-statement that encompassed two conditions:

1. trajectory is empty
2. the end state of one segment differs from the start state of the next segment

In both cases, the whole trajectory segment was appended with a dt=0. However, that's correct only for case 1. 
In case 2, we needed to apply a non-zero time offset dictated by the actual dt of that segment's first waypoint.
