### PR TITLE
explicitly deactivate ruckig webclient support in MoveIt build

### DIFF
--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -50,9 +50,8 @@ find_package(ruckig REQUIRED)
 # in include_directories below because the target is correctly imported here.
 get_target_property(ruckig_INCLUDE_DIRS ruckig::ruckig INTERFACE_INCLUDE_DIRECTORIES)
 set(ruckig_LIBRARIES "ruckig::ruckig")
-# ruckig built with cloud client (default) does not automatically pull in nlohmann_json
-# and MoveIt can fail to build in install workspaces because of this.
-# Remove the WITH_CLOUD_CLIENT definition because we don't use it anyway.
+# Remove the WITH_CLOUD_CLIENT definition because we don't use it and it causes build issues in some configurations
+# See https://github.com/moveit/moveit/pull/3636
 get_target_property(ruckig_defs ruckig::ruckig INTERFACE_COMPILE_DEFINITIONS)
 if(ruckig_defs)
   list(REMOVE_ITEM ruckig_defs "WITH_CLOUD_CLIENT")

--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -50,6 +50,14 @@ find_package(ruckig REQUIRED)
 # in include_directories below because the target is correctly imported here.
 get_target_property(ruckig_INCLUDE_DIRS ruckig::ruckig INTERFACE_INCLUDE_DIRECTORIES)
 set(ruckig_LIBRARIES "ruckig::ruckig")
+# ruckig built with cloud client (default) does not automatically pull in nlohmann_json
+# and MoveIt can fail to build in install workspaces because of this.
+# Remove the WITH_CLOUD_CLIENT definition because we don't use it anyway.
+get_target_property(ruckig_defs ruckig::ruckig INTERFACE_COMPILE_DEFINITIONS)
+if(ruckig_defs)
+  list(REMOVE_ITEM ruckig_defs "WITH_CLOUD_CLIENT")
+  set_target_properties(ruckig::ruckig PROPERTIES INTERFACE_COMPILE_DEFINITIONS "${ruckig_defs}")
+endif()
 
 find_package(urdfdom REQUIRED)
 find_package(urdfdom_headers REQUIRED)


### PR DESCRIPTION
... even when ruckig is built with it.

When ruckig is built with the cloud client (which is on by default), it relies on the third_party nlohmann library bundled in the git. But it does not install these headers. If ruckig and MoveIt are built together and ruckig is built in an install workspace, that makes the MoveIt build fail by default.

Note that this problem does not occur when the debian package `nlohmann-json3-dev` is installed because it is implicitly picked up. But ruckig does not automatically pull in nlohmann_json through package.xml depends tags (because it's optional and bundled for dev builds).

I suggest to remove the WITH_CLOUD_CLIENT definition in MoveIt's use through the patch because we don't use it anyway.

This is relevant for me because I'm trying to set up a builder for both that uses defaults and thus run into the build failure.

@pantor for reference.