### PR TITLE
servo: use ACM consistently

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/collision_check.h
@@ -95,9 +95,8 @@ private:
   // Pointer to the collision environment
   planning_scene_monitor::PlanningSceneMonitorPtr planning_scene_monitor_;
 
-  // Robot state and collision matrix from planning scene
-  std::shared_ptr<moveit::core::RobotState> current_state_;
-  collision_detection::AllowedCollisionMatrix acm_;
+  // RobotState buffer used for collision checking
+  robot_state::RobotStatePtr current_state_;
 
   // Scale robot velocity according to collision proximity and user-defined thresholds.
   // I scaled exponentially (cubic power) so velocity drops off quickly after the threshold.


### PR DESCRIPTION
- do not copy acm from monitored scene (ignoring later updates)
- also do not lock scene twice for related checks
- do not cache shared_ptr, but actual RobotState, caching the ptr is useless

Please have a look @torydebra

Alternative to #3640 .

Fixes #3639 .