### PR TITLE
Set joint trajectory with actual robot pose

### DIFF
--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -351,19 +351,13 @@ void ServoCalcs::calculateSingleIteration()
   else
   {
     // Joint trajectory is not populated with anything, so set it to the last positions and 0 velocity
-    joint_trajectory->header = last_sent_command_->header;
-    trajectory_msgs::JointTrajectoryPoint point;
-    point.time_from_start = ros::Duration(parameters_.publish_period);
-
-    current_state_->copyJointGroupPositions(joint_model_group_, point.positions);
+    joint_trajectory = last_sent_command_;
     for (auto& point : joint_trajectory->points)
     {
+      current_state_->copyJointGroupPositions(joint_model_group_, point.positions);
       point.velocities.assign(point.velocities.size(), 0);
       point.accelerations.assign(point.accelerations.size(), 0);
     }
-
-    joint_trajectory->points.clear();
-    joint_trajectory->points.push_back(point);
   }
 
   // Print a warning to the user if both are stale

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -351,11 +351,19 @@ void ServoCalcs::calculateSingleIteration()
   else
   {
     // Joint trajectory is not populated with anything, so set it to the last positions and 0 velocity
-    *joint_trajectory = *last_sent_command_;
+    joint_trajectory->header = last_sent_command_->header;
+    trajectory_msgs::JointTrajectoryPoint point;
+    point.time_from_start = ros::Duration(parameters_.publish_period);
+
+    current_state_->copyJointGroupPositions(joint_model_group_, point.positions);
     for (auto& point : joint_trajectory->points)
     {
       point.velocities.assign(point.velocities.size(), 0);
+      point.accelerations.assign(point.accelerations.size(), 0);
     }
+
+    joint_trajectory->points.clear();
+    joint_trajectory->points.push_back(point);
   }
 
   // Print a warning to the user if both are stale

--- a/moveit_ros/moveit_servo/src/servo_calcs.cpp
+++ b/moveit_ros/moveit_servo/src/servo_calcs.cpp
@@ -351,7 +351,7 @@ void ServoCalcs::calculateSingleIteration()
   else
   {
     // Joint trajectory is not populated with anything, so set it to the last positions and 0 velocity
-    joint_trajectory = last_sent_command_;
+    *joint_trajectory = *last_sent_command_;
     for (auto& point : joint_trajectory->points)
     {
       current_state_->copyJointGroupPositions(joint_model_group_, point.positions);


### PR DESCRIPTION
See #3638 

I am not sure if this is the best way to get the joint state and populate the joint trajectory. 
For example, velocities are zero, should copyJointGroupVelocity be used instead? Probably will not change much.


### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
