### PR TITLE
Ignoring links planning scene monitor

### DIFF
--- a/moveit_ros/planning/moveit_cpp/test/moveit_cpp.yaml
+++ b/moveit_ros/planning/moveit_cpp/test/moveit_cpp.yaml
@@ -6,6 +6,9 @@ planning_scene_monitor_options:
   publish_planning_scene_topic: "/publish_planning_scene"
   monitored_planning_scene_topic: "/monitored_planning_scene"
   wait_for_initial_state_timeout: 10.0
+  # ignored_frames: 
+  #   - ignored_frame_1
+  #   - ignored_frame_2
 
 planning_pipelines:
   pipeline_names:

--- a/moveit_ros/planning/moveit_cpp/test/moveit_cpp.yaml
+++ b/moveit_ros/planning/moveit_cpp/test/moveit_cpp.yaml
@@ -6,7 +6,7 @@ planning_scene_monitor_options:
   publish_planning_scene_topic: "/publish_planning_scene"
   monitored_planning_scene_topic: "/monitored_planning_scene"
   wait_for_initial_state_timeout: 10.0
-  # ignored_frames: 
+  # ignored_frames:
   #   - ignored_frame_1
   #   - ignored_frame_2
 

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -585,6 +585,9 @@ private:
 
   class DynamicReconfigureImpl;
   DynamicReconfigureImpl* reconfigure_impl_;
+
+  std::set<std::string> ignored_frames_;
+  bool checkFrameIgnored(const std::string& frame);
 };
 
 /** \brief This is a convenience class for obtaining access to an

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -1476,8 +1476,8 @@ void PlanningSceneMonitor::configureDefaultPadding()
   ROS_DEBUG_STREAM_NAMED(LOGNAME, "Loaded " << default_robot_link_scale_.size() << " default link scales");
 }
 
-bool PlanningSceneMonitor::checkFrameIgnored(const std::string& frame) {
-
+bool PlanningSceneMonitor::checkFrameIgnored(const std::string& frame)
+{
   return (ignored_frames_.find(frame) != ignored_frames_.end());
 }
 }  // namespace planning_scene_monitor

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -259,6 +259,10 @@ void PlanningSceneMonitor::initialize(const planning_scene::PlanningScenePtr& sc
                                             false);  // do not start the timer yet
 
   reconfigure_impl_ = new DynamicReconfigureImpl(this);
+
+  std::vector<std::string> ignored_frames_vector;
+  nh_.param("planning_scene_monitor_options/ignored_frames", ignored_frames_vector, std::vector<std::string>());
+  ignored_frames_ = std::set<std::string>(ignored_frames_vector.begin(), ignored_frames_vector.end());
 }
 
 void PlanningSceneMonitor::monitorDiffs(bool flag)
@@ -1336,7 +1340,7 @@ void PlanningSceneMonitor::getUpdatedFrameTransforms(std::vector<geometry_msgs::
   tf_buffer_->_getFrameStrings(all_frame_names);
   for (const std::string& all_frame_name : all_frame_names)
   {
-    if (all_frame_name == target || getRobotModel()->hasLinkModel(all_frame_name))
+    if (all_frame_name == target || getRobotModel()->hasLinkModel(all_frame_name) || checkFrameIgnored(all_frame_name))
       continue;
 
     geometry_msgs::TransformStamped f;
@@ -1470,5 +1474,10 @@ void PlanningSceneMonitor::configureDefaultPadding()
 
   ROS_DEBUG_STREAM_NAMED(LOGNAME, "Loaded " << default_robot_link_padd_.size() << " default link paddings");
   ROS_DEBUG_STREAM_NAMED(LOGNAME, "Loaded " << default_robot_link_scale_.size() << " default link scales");
+}
+
+bool PlanningSceneMonitor::checkFrameIgnored(const std::string& frame) {
+
+  return (ignored_frames_.find(frame) != ignored_frames_.end());
 }
 }  // namespace planning_scene_monitor


### PR DESCRIPTION
### Description

I was annoyed by continuos tf ROS warning like
~~~
[ WARN] [/cmd_to_moveit] [PlanningSceneMonitor::getUpdatedFrameTransforms]: Unable to transform object from frame 'box_cloud_0' to planning frame 'world' (Lookup would require extrapolation 1.067000000s into the past.  Requested time 607.296000000 but the earliest data is at time 608.363000000, when looking up transform from frame [box_cloud_0] to frame [world])
~~~
that was correctly happening because at some point one frame is not in published anymore (as wanted).

This was caused by:
https://github.com/moveit/moveit/blob/2e5b70cd480ddb1b43b21bc79a878512d4f3c93a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp#L1342-L1350

Since I do not care that the planning scene monitor consider such frames, I added an "ignored_frames" params. 

Please check if this makes any sense to you

Thanks



### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
