### PR TITLE
Execute while planning

### DIFF
--- a/moveit_ros/move_group/src/move_group.cpp
+++ b/moveit_ros/move_group/src/move_group.cpp
@@ -203,7 +203,7 @@ int main(int argc, char** argv)
 {
   ros::init(argc, argv, move_group::NODE_NAME);
 
-  ros::AsyncSpinner spinner(1);
+  ros::AsyncSpinner spinner(2);
   spinner.start();
 
   // Load MoveItCpp parameters and check for valid planning pipeline configuration

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -1300,7 +1300,13 @@ void PlanningSceneMonitor::updateSceneWithCurrentState()
     }
 
     {
-      boost::unique_lock<boost::shared_mutex> ulock(scene_update_mutex_);
+      // Return if we can't lock scene_update_mutex rather than waiting,
+      // so the current state monitor isn't blocked.
+      boost::unique_lock<boost::shared_mutex> ulock(scene_update_mutex_, boost::try_to_lock);
+      if (not ulock)
+      {
+        return;
+      }
       last_update_time_ = last_robot_motion_time_ = current_state_monitor_->getCurrentStateTime();
       ROS_DEBUG_STREAM_NAMED(LOGNAME, "robot state update " << fmod(last_robot_motion_time_.toSec(), 10.));
       current_state_monitor_->setToCurrentState(scene_->getCurrentStateNonConst());


### PR DESCRIPTION

### Description

 - Fixes #3562
 - Fixes #3563
 - Adds a second thread to the spinner in `move_group.cpp`, allowing two capabilities to run at once. This is intended to allow the `TrajectoryExecutionManager` to execute trajectories while planning is happening.
 - Makes `PlanningSceneMonitor::updateSceneWithCurrentState` return early if the mutex is locked, rather than waiting for the mutex. This allows the `CurrentStateMonitor` to continue updating while the `PlanningSceneMonitor` is locked, allowing the `TrajectoryExecutionManager` to grab fresh states while planning is happening.

Open questions:
 - Adding a second spinner to `move_group.cpp` is likely to allow a whole raft of new race conditions. Do we now need a set of mutexes around capabilities to prevent these?
 - Is this change to `PlanningSceneMonitor` the best way to avoid locking out the `CurrentStateMonitor`? Or do we want something a little more targeted to the specific callback the `PlanningSceneMonitor` adds to the `CurrentStateMonitor`?

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
