### PR TITLE
Remove ACM entries when removing collision objects

### DIFF
--- a/moveit_core/planning_scene/src/planning_scene.cpp
+++ b/moveit_core/planning_scene/src/planning_scene.cpp
@@ -442,6 +442,7 @@ void PlanningScene::pushDiffs(const PlanningScenePtr& scene)
         scene->world_->removeObject(it.first);
         scene->removeObjectColor(it.first);
         scene->removeObjectType(it.first);
+        scene->getAllowedCollisionMatrixNonConst().removeEntry(it.first);
       }
       else
       {
@@ -1417,6 +1418,7 @@ void PlanningScene::removeAllCollisionObjects()
       world_->removeObject(object_id);
       removeObjectColor(object_id);
       removeObjectType(object_id);
+      getAllowedCollisionMatrixNonConst().removeEntry(object_id);
     }
 }
 
@@ -1875,6 +1877,7 @@ bool PlanningScene::processCollisionObjectRemove(const moveit_msgs::CollisionObj
 
     removeObjectColor(object.id);
     removeObjectType(object.id);
+    getAllowedCollisionMatrixNonConst().removeEntry(object.id);
   }
   return true;
 }


### PR DESCRIPTION
Backport of https://github.com/moveit/moveit2/pull/3183