### PR TITLE
PSM: Fix handling of flag state_update_pending_

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -557,7 +557,7 @@ private:
   // Lock for state_update_pending_ and dt_state_update_
   boost::mutex state_pending_mutex_;
 
-  /// True when we need to update the RobotState from current_state_monitor_
+  /// True if current_state_monitor_ has a newer RobotState than scene_
   // This field is protected by state_pending_mutex_
   volatile bool state_update_pending_;
 
@@ -571,7 +571,7 @@ private:
   ros::Duration shape_transform_cache_lookup_wait_time_;
 
   /// timer for state updates.
-  // Check if last_state_update_ is true and if so call updateSceneWithCurrentState()
+  // If state_update_pending_ is true, call updateSceneWithCurrentState()
   // Not safe to access from callback functions.
   ros::WallTimer state_update_timer_;
 

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -1264,7 +1264,7 @@ void PlanningSceneMonitor::updateSceneWithCurrentState(bool skip_update_if_locke
       boost::unique_lock<boost::shared_mutex> ulock(scene_update_mutex_, boost::defer_lock);
       if (!skip_update_if_locked)
         ulock.lock();
-      else if (!ulock.try_lock_for(boost::chrono::milliseconds(100)))
+      else if (!ulock.try_lock())
         // Return if we can't lock scene_update_mutex within 100ms, thus not blocking CurrentStateMonitor too long
         return;
 

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -1179,15 +1179,16 @@ void PlanningSceneMonitor::stopStateMonitor()
 
 void PlanningSceneMonitor::onStateUpdate(const sensor_msgs::JointStateConstPtr& /* joint_state */)
 {
-  const ros::WallTime& n = ros::WallTime::now();
-  ros::WallDuration dt = n - last_robot_state_update_wall_time_;
+  bool update = false;
 
   {
     boost::mutex::scoped_lock lock(state_pending_mutex_);
     state_update_pending_ = true;
+    // only update every dt_state_update_ seconds
+    update = ros::WallTime::now() - last_robot_state_update_wall_time_ >= dt_state_update_;
   }
   // run the state update with state_pending_mutex_ unlocked
-  if (dt >= dt_state_update_)  // throttling condition
+  if (update)
     updateSceneWithCurrentState(true);
 }
 

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -1264,8 +1264,8 @@ void PlanningSceneMonitor::updateSceneWithCurrentState(bool skip_update_if_locke
       boost::unique_lock<boost::shared_mutex> ulock(scene_update_mutex_, boost::defer_lock);
       if (!skip_update_if_locked)
         ulock.lock();
-      else if (!ulock.try_lock_for(boost::chrono::duration<double>(std::min(0.1, 0.1 * dt_state_update_.toSec()))))
-        // Return if we can't lock scene_update_mutex, thus not blocking CurrentStateMonitor
+      else if (!ulock.try_lock_for(boost::chrono::milliseconds(100)))
+        // Return if we can't lock scene_update_mutex within 100ms, thus not blocking CurrentStateMonitor too long
         return;
 
       last_update_time_ = last_robot_motion_time_ = current_state_monitor_->getCurrentStateTime();

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -1195,7 +1195,7 @@ void PlanningSceneMonitor::onStateUpdate(const sensor_msgs::JointStateConstPtr& 
 void PlanningSceneMonitor::stateUpdateTimerCallback(const ros::WallTimerEvent& /*unused*/)
 {
   if (state_update_pending_ && ros::WallTime::now() - last_robot_state_update_wall_time_ >= dt_state_update_)
-    updateSceneWithCurrentState();
+    updateSceneWithCurrentState(true);
 }
 
 void PlanningSceneMonitor::octomapUpdateCallback()

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -1275,10 +1275,11 @@ void PlanningSceneMonitor::updateSceneWithCurrentState(bool skip_update_if_locke
     }
 
     // Update state_pending_mutex_ and last_robot_state_update_wall_time_
-    boost::mutex::scoped_lock lock(state_pending_mutex_);
-    state_update_pending_ = false;
-    last_robot_state_update_wall_time_ = ros::WallTime::now();
-    lock.unlock();
+    {
+      boost::mutex::scoped_lock lock(state_pending_mutex_);
+      state_update_pending_ = false;
+      last_robot_state_update_wall_time_ = ros::WallTime::now();
+    }
 
     triggerSceneUpdateEvent(UPDATE_STATE);
   }


### PR DESCRIPTION
Follow up on #3676, implementing [@v4hn's suggestion](https://github.com/moveit/moveit/pull/3676#discussion_r1904504928) to update `state_update_pending_` and `last_robot_state_update_wall_time_` only within updateSceneWithCurrentState() - where the update is actually performed.

This nicely simplifies all the code :tada: