### PR TITLE
use opaque scene alpha by default

### DIFF
--- a/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
+++ b/moveit_ros/visualization/planning_scene_rviz_plugin/src/planning_scene_display.cpp
@@ -96,7 +96,7 @@ PlanningSceneDisplay::PlanningSceneDisplay(bool listen_to_planning_scene, bool s
       new rviz::BoolProperty("Show Scene Geometry", true, "Indicates whether planning scenes should be displayed",
                              scene_category_, SLOT(changedSceneEnabled()), this);
 
-  scene_alpha_property_ = new rviz::FloatProperty("Scene Alpha", 0.9f, "Specifies the alpha for the scene geometry",
+  scene_alpha_property_ = new rviz::FloatProperty("Scene Alpha", 1.0f, "Specifies the alpha for the scene geometry",
                                                   scene_category_, SLOT(changedSceneAlpha()), this);
   scene_alpha_property_->setMin(0.0);
   scene_alpha_property_->setMax(1.0);


### PR DESCRIPTION
This annoyed me since 2016. I have no idea why I never made that patch...

0.9 is not actually very transparent and can introduce rendering artifacts with transparency in RViz. Especially when the scene includes meshes this often looks weird (I believe this issue was discussed in some RViz issues in the past but I can't find the thread right now).

Alpha=0.9 versus 1.0:
![scene-alpha2](https://github.com/user-attachments/assets/a685d8b6-5a5c-41a6-a218-39426ddc1afc)

Independent of a potential improvement to rendering in RViz, I suggest to simply fix the non-intuitive default of 0.9.