### PR TITLE
Fix race condition in TrajectoryVisualization::incomingDisplayTrajectory

### DIFF
--- a/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
+++ b/moveit_ros/visualization/rviz_plugin_render_tools/src/trajectory_visualization.cpp
@@ -538,8 +538,6 @@ void TrajectoryVisualization::incomingDisplayTrajectory(const moveit_msgs::Displ
     ROS_WARN("Received a trajectory to display for model '%s' but model '%s' was expected", msg->model_id.c_str(),
              robot_model_->getName().c_str());
 
-  trajectory_message_to_display_.reset();
-
   robot_trajectory::RobotTrajectoryPtr t(new robot_trajectory::RobotTrajectory(robot_model_, ""));
   try
   {


### PR DESCRIPTION
### Description

There is a data race on trajectory_message_to_display_ shared pointer. In practice, this data race manifests itself as a TOCTOU bug.

One possible execution order that leads to a null pointer dereference:

- Thread A calls TrajectoryVisualization::update()
- Thread A locks update_trajectory_message_ mutex
- Thread A checks that trajectory_message_to_display_ is valid
- Thread B calls TrajectoryVisualization::incomingDisplayTrajectory
- Thread B invalidates the trajectory_message_to_display_ pointer by calling trajectory_message_to_display_.reset()
- Thread A tries to call trajectory_message_to_display_->getWayPointCount(), causing a null pointer dereference.

Since there is no reason to reset the pointer at that location, we fix the bug by simply removing the call to trajectory_message_to_display_.reset().

### Checklist
- [x] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the [MIGRATION.md](https://github.com/moveit/moveit/blob/master/MIGRATION.md) notes
- [ ] Create tests, which fail without this PR [reference](https://moveit.github.io/moveit_tutorials/doc/tests/tests_tutorial.html)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/moveit/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
