### PR TITLE
CI: Stop syncing noetic-devel with master

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -174,23 +174,3 @@ jobs:
           sudo find ${{ env.BASEDIR }}/target_ws -wholename '*/test_results/*' -delete
           sudo rm -rf ${{ env.BASEDIR }}/target_ws/src ${{ env.BASEDIR }}/target_ws/logs
           du -sh ${{ env.BASEDIR }}/target_ws
-
-  # Sync noetic-devel branch with master on successful build
-  sync-noetic-devel:
-    runs-on: ubuntu-latest
-    needs: default # only trigger on success of default build job
-    if: github.event_name == 'push' && github.repository_owner == 'moveit' && github.ref == 'refs/heads/master'
-    permissions:
-      contents: write # allow pushing
-    steps:
-      - uses: actions/checkout@v4
-      - name: Fast-forward noetic-devel to sync with master
-        run: |
-          # Configure push user+url
-          git config --global user.name 'GHA sync bot'
-          git config --global user.email 'rhaschke@users.noreply.github.com'
-          git remote set-url origin https://x-access-token:${{ secrets.GH_PAGES_TOKEN }}@github.com/${{ github.repository }}
-          # Extend shallow copy from actions/checkout to connect noetic-devel..master
-          git fetch --depth=1 origin noetic-devel
-          git fetch --depth=200 origin master
-          git push origin master:noetic-devel


### PR DESCRIPTION
Given that Noetic is EOL, I suggest to:
- stop supporting Ubuntu Focal and focus on ROS One development on Jammy and newer Ubuntu versions
- stop syncing the noetic-devel branch with master to indicate this freeze in the git branch structure